### PR TITLE
remplacement du bouton réserver dans le mode laborantin

### DIFF
--- a/app/templates/home.html
+++ b/app/templates/home.html
@@ -59,13 +59,24 @@
                             <button class="supp_produit"><img src="{{url_for('static', filename='images/supp_produit.png')}}"></button>
                         {% endif %}
                         <p class="nomProduit">{{produit.nomProduit}}   <button class="info_prod" data-produit="{{ produit.idProduit }}"><img src="{{url_for('static', filename='images/info_produit.png')}}" alt ="i"></button></p>
+                        <!-- A restructurer -->
                         {% if qte > 0 %}
                             <p class="dispo">Disponible</p>
                             <div class="bouton">
                                 {% if current_user.estPreparateur %}
                                     <button class="Modifier" data-produit="{{ produit.idProduit }}"> Modifier <img src="{{url_for('static', filename='images/modifier.png')}}" alt =""></button>
+                                    {% if produit.fonctionProduit == None %}
+                                    <button class="famille bdisabled" disabled>
+                                        Produits de la même famille
+                                    </button>
+                                    {% else %}
+                                        <button class="famille" onclick="window.location.href='{{ url_for('searchByButton', id_produit=produit.idProduit) }}'">
+                                            Produits de la même famille
+                                        </button>
+                                    {% endif %}
+                                {% else %}
+                                    <button class="Reserver" data-produit="{{ produit.idProduit }}"> Reserver <img src="{{url_for('static', filename='images/reserver.png')}}" alt =""></button>
                                 {% endif %}
-                                <button class="Reserver" data-produit="{{ produit.idProduit }}"> Reserver <img src="{{url_for('static', filename='images/reserver.png')}}" alt =""></button>
                             </div>
                         {% else %}
                             <p class="dispo">Indisponible</p>


### PR DESCRIPTION
Il est inutile d'avoir un bonton réserver pour un laborantin, il a été remplacé par un bouton pour trouver les produits de la même manière